### PR TITLE
inject front.js into footer

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -30,7 +30,8 @@ if (!class_exists('ISC_Public')) {
         * Enqueue scripts for the front-end.
         */
         public function front_scripts() {
-            wp_enqueue_script('isc_front_js', plugins_url('/assets/js/front-js.js', __FILE__), array('jquery'), ISCVERSION);
+            // inject in footer as we only do stuff after dom-ready
+            wp_enqueue_script('isc_front_js', plugins_url('/assets/js/front-js.js', __FILE__), array('jquery'), ISCVERSION, true);
         }
 
                 /**

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,8 @@ e.g.
 
 == Changelog ==
 
+* load public javascript in footer by default
+
 = 1.8.11.2 =
 
 * fixed align value not being understood correctly


### PR DESCRIPTION
As the front.js only runs on dom-ready (jQuery) it is not needed in head and will just slow down clients / make it harder to integrate into optimised sites that have no head-scripts.