### PR TITLE
remove deprecated alias load-event

### DIFF
--- a/public/assets/js/front-js.js
+++ b/public/assets/js/front-js.js
@@ -27,7 +27,7 @@ jQuery(function(){
     jQuery(window).resize(function(){
         isc_update_captions_positions();
     });
-    jQuery('.isc-source img').load(function(){
+    jQuery('.isc-source img').on('load', function(){
         isc_update_captions_positions();
     });
 });


### PR DESCRIPTION
This alias method was deprecated with jQuery 1.8 in favour of `jQuery.on('load', handler)`.

`jQuery.on()` was added in version 1.7 in November 2011 to improve HTML 5 support in jQuery.
If backwards compatibility is a concern for you either a test like

```
var img = jQuery('.isc-source img');
if ('on' in img) {
    // jQuery 1.7+
    img.on('load', isc_update_captions_positions)
} else {
    // jQuery <1.7
    img.load(isc_update_captions_positions);
}
```

would be needed.