### PR TITLE
Expanded default list of licenses

### DIFF
--- a/isc.class.php
+++ b/isc.class.php
@@ -421,6 +421,34 @@ class ISC_Class {
             $default['source_pretext'] = __('Source:', 'image-source-control-isc');
             $default['enable_licences'] = false;
             $default['licences'] = __("CC BY 2.0|http://creativecommons.org/licenses/by/2.0/legalcode", 'image-source-control-isc');
+            $default['licences'] = __("All Rights Reserved
+Public Domain Mark 1.0|https://creativecommons.org/publicdomain/mark/1.0/
+CC0 1.0 Universal|https://creativecommons.org/publicdomain/zero/1.0/
+CC BY 4.0 International|https://creativecommons.org/licenses/by/4.0/
+CC BY-SA 4.0 International|https://creativecommons.org/licenses/by-sa/4.0/
+CC BY-ND 4.0 International|https://creativecommons.org/licenses/by-nd/4.0/
+CC BY-NC 4.0 International|https://creativecommons.org/licenses/by-nc/4.0/
+CC BY-NC-SA 4.0 International|https://creativecommons.org/licenses/by-nc-sa/4.0/
+CC BY-NC-ND 4.0 International|https://creativecommons.org/licenses/by-nc-nd/4.0/
+CC BY 3.0 Unported|https://creativecommons.org/licenses/by/3.0/
+CC BY-SA 3.0 Unported|https://creativecommons.org/licenses/by-sa/3.0/
+CC BY-ND 3.0 Unported|https://creativecommons.org/licenses/by-nd/3.0/
+CC BY-NC 3.0 Unported|https://creativecommons.org/licenses/by-nc/3.0/
+CC BY-NC-SA 3.0 Unported|https://creativecommons.org/licenses/by-nc-sa/3.0/
+CC BY-NC-ND 3.0 Unported|https://creativecommons.org/licenses/by-nc-nd/3.0/
+CC BY 2.5 Generic|https://creativecommons.org/licenses/by/2.5/
+CC BY-SA 2.5 Generic|https://creativecommons.org/licenses/by-sa/2.5/
+CC BY-ND 2.5 Generic|https://creativecommons.org/licenses/by-nd/2.5/
+CC BY-NC 2.5 Generic|https://creativecommons.org/licenses/by-nc/2.5/
+CC BY-NC-SA 2.5 Generic|https://creativecommons.org/licenses/by-nc-sa/2.5/
+CC BY-NC-ND 2.5 Generic|https://creativecommons.org/licenses/by-nc-nd/2.5/
+CC BY 2.0 Generic|https://creativecommons.org/licenses/by/2.0/
+CC BY-SA 2.0 Generic|https://creativecommons.org/licenses/by-sa/2.0/
+CC BY-ND 2.0 Generic|https://creativecommons.org/licenses/by-nd/2.0/
+CC BY-NC 2.0 Generic|https://creativecommons.org/licenses/by-nc/2.0/
+CC BY-NC-SA 2.0 Generic|https://creativecommons.org/licenses/by-nc-sa/2.0/
+CC BY-NC-ND 2.0 Generic|https://creativecommons.org/licenses/by-nc-nd/2.0/
+", 'image-source-control-isc');
             return $default;
         }
 

--- a/isc.class.php
+++ b/isc.class.php
@@ -420,7 +420,6 @@ class ISC_Class {
             $default['caption_position'] = 'top-left';
             $default['source_pretext'] = __('Source:', 'image-source-control-isc');
             $default['enable_licences'] = false;
-            $default['licences'] = __("CC BY 2.0|http://creativecommons.org/licenses/by/2.0/legalcode", 'image-source-control-isc');
             $default['licences'] = __("All Rights Reserved
 Public Domain Mark 1.0|https://creativecommons.org/publicdomain/mark/1.0/
 CC0 1.0 Universal|https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Hi,

I expanded the list of default licenses to make it so writers using Creative Commons licenses doesn't have to compile a list--since there are a lot--they can build a new list from the default provided. Creative Commons versions 2.0, 2.5, and 3.0, though old, were included due to image repositories are still using either of these older versions.

Cheers!
