### PR TITLE
Use license for en_US base

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -21,9 +21,9 @@ if (!class_exists('ISC_Admin')) {
          * @since 1.7
          */
         public function __construct() {
-            
+
             parent::__construct();
-            
+
             register_activation_hook(ISCPATH . '../isc.php', array($this, 'activation'));
 
             // attachment field handling
@@ -55,7 +55,7 @@ if (!class_exists('ISC_Admin')) {
         */
         public function admin_notices()
         {
-            
+
                 // only check, if check-option was enabled
                 $options = $this->get_isc_options();
                 if( empty( $options['warning_onesource_missing'] ) ){
@@ -63,7 +63,7 @@ if (!class_exists('ISC_Admin')) {
                 };
 
                 $show_warning = get_transient( 'isc-show-missing-sources-warning' );
-                
+
                 // attachments without sources
                 if( ! $show_warning ){
                         $args = array(
@@ -85,7 +85,7 @@ if (!class_exists('ISC_Admin')) {
                             )
                         );
                         $attachments = get_posts($args);
-                        
+
                         if( !empty( $attachments ) ){
                                 $show_warning = true;
                         } else {
@@ -109,10 +109,10 @@ if (!class_exists('ISC_Admin')) {
                                 }
                         }
                 }
-                
+
                 if ( $show_warning ){
                         $missing_src = esc_url(admin_url('upload.php?page=isc_missing_sources_page'));
-                        ?><div class="error"><p><?php 
+                        ?><div class="error"><p><?php
                                 printf(__('One or more attachments still have no source. See the <a href="%s">missing sources</a> list', 'image-source-control-isc'), $missing_src);
                                 ?></p></div><?php
                 }
@@ -165,7 +165,7 @@ if (!class_exists('ISC_Admin')) {
          *
          * @since 1.0
          * @updated 1.1
-         * @updated 1.3.5 added field for licence
+         * @updated 1.3.5 added field for license
          * @updated 1.5 added field for url
 
          * @param arr $form_fields
@@ -199,8 +199,8 @@ if (!class_exists('ISC_Admin')) {
             $options = $this->get_isc_options();
             if($options['enable_licences'] && $licences = $this->licences_text_to_array($options['licences'])) {
                 $form_fields['isc_image_licence']['input'] = 'html';
-                $form_fields['isc_image_licence']['label'] = __('Image Licence', 'image-source-control-isc');
-                $form_fields['isc_image_licence']['helps'] = __('Choose the image licence.', 'image-source-control-isc');
+                $form_fields['isc_image_licence']['label'] = __('Image License', 'image-source-control-isc');
+                $form_fields['isc_image_licence']['helps'] = __('Choose the image license.', 'image-source-control-isc');
                 $html = '<select name="attachments['.$post->ID.'][isc_image_licence]" id="attachments['.$post->ID.'][isc_image_licence]">';
                     $html .= '<option value="">--</option>';
                 foreach($licences as $_licence_name => $_licence_data) {
@@ -236,16 +236,16 @@ if (!class_exists('ISC_Admin')) {
             if (isset($attachment['isc_image_licence'])) {
                 update_post_meta($post['ID'], 'isc_image_licence', $attachment['isc_image_licence']);
             }
-            
+
             // remove transient that shows the warning, if true, to re-check image source warning with next call to admin_notices()
             $options = $this->get_isc_options();
             if( isset( $options['warning_onesource_missing'] )
-                    && $options['warning_onesource_missing'] 
+                    && $options['warning_onesource_missing']
                     && get_transient( 'isc-show-missing-sources-warning' ) ){
-                    
+
                     delete_transient( 'isc-show-missing-sources-warning' );
             };
-            
+
             return $post;
         }
 
@@ -258,21 +258,21 @@ if (!class_exists('ISC_Admin')) {
         {
             // return, if save_post is called more than one time
             if ( did_action('save_post') !== 1
-                || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
+                || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
                 || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
                 return;
             }
-            
+
             /**
              * don’t save meta data for non-public post types, since those shouldn’t be visible in the frontend
              * ignore also attachment posts
              */
-            if ( ! isset( $_POST['post_type'] ) 
+            if ( ! isset( $_POST['post_type'] )
                     || ! in_array( $_POST['post_type'], get_post_types( array( 'public' => true ), 'names' ) ) // is the post type public
                     || 'attachment' == $_POST['post_type']) {
                 return;
             }
-            
+
             // check if this is a revision and if so, use parent post id
             if ($_id = wp_is_post_revision($post_id)) {
                 $post_id = $_id;
@@ -381,8 +381,8 @@ if (!class_exists('ISC_Admin')) {
             add_settings_field('thumbnail_height', __("Thumbnails max-height", 'image-source-control-isc'), array($this, 'renderfield_thumbnail_height'), 'isc_settings_page', 'isc_settings_section');
 
             // Licence settings group
-            add_settings_field('enable_licences', __("Enable licences", 'image-source-control-isc'), array($this, 'renderfield_enable_licences'), 'isc_settings_page', 'isc_settings_section');
-            add_settings_field('licences', __('List of licences', 'image-source-control-isc'), array($this, 'renderfield_licences'), 'isc_settings_page', 'isc_settings_section');
+            add_settings_field('enable_licences', __("Enable licenses", 'image-source-control-isc'), array($this, 'renderfield_enable_licences'), 'isc_settings_page', 'isc_settings_section');
+            add_settings_field('licences', __('List of licenses', 'image-source-control-isc'), array($this, 'renderfield_licences'), 'isc_settings_page', 'isc_settings_section');
 
             // Misc settings group
             add_settings_field('exclude_own_images', __('Exclude own images', 'image-source-control-isc'), array($this, 'renderfield_exclude_own_images'), 'isc_settings_page', 'isc_settings_section');
@@ -638,7 +638,7 @@ if (!class_exists('ISC_Admin')) {
         public function renderfield_enable_licences()
         {
             $options = $this->get_isc_options();
-            $description = __("Enable this to be able to add and display copyright/copyleft licences for your images and manage them in the field below.", 'image-source-control-isc');
+            $description = __("Enable this to be able to add and display copyright/copyleft licenses for your images and manage them in the field below.", 'image-source-control-isc');
 
             ?>
             <div id="enable-licences">
@@ -651,8 +651,8 @@ if (!class_exists('ISC_Admin')) {
         public function renderfield_licences()
         {
             $options = $this->get_isc_options();
-            $description = __('List of licences the author can choose for an image. Enter a licence per line and separate the name from the optional link with a pipe symbol (e.g. <em>CC BY 2.0|http://creativecommons.org/licenses/by/2.0/legalcode</em>).' ,'image-source-control-isc');
-            
+            $description = __('List of licenses the author can choose for an image. Enter a license per line and separate the name from the optional link with a pipe symbol (e.g. <em>CC BY 2.0|http://creativecommons.org/licenses/by/2.0/legalcode</em>).' ,'image-source-control-isc');
+
             // fall back to default if field is empty
             if( empty( $options['licences'] ) ){
                     // retrieve default options
@@ -661,7 +661,7 @@ if (!class_exists('ISC_Admin')) {
                             $options['licences'] = $default['licences'];
                     }
             }
-            
+
             ?>
             <div id="licences">
                 <textarea name="isc_options[licences]"><?php echo $options['licences'] ?></textarea>
@@ -728,7 +728,7 @@ if (!class_exists('ISC_Admin')) {
             </td></tr></tbody></table>
             </div><!-- .postbox -->
             <div class="postbox isc-setting-group">
-            <h3 class="setting-group-head"><?php _e('Licences settings', 'image-source-control-isc'); ?></h3>
+            <h3 class="setting-group-head"><?php _e('Licenses settings', 'image-source-control-isc'); ?></h3>
             <table class="form-table"><tbody><tr>
             <?php
         }
@@ -883,7 +883,7 @@ if (!class_exists('ISC_Admin')) {
         /**
         * Input validation function.
         * @param array $input values from the admin panel
-         * @updated 1.3.5 added licences fields
+         * @updated 1.3.5 added licenses fields
         */
         public function settings_validation($input)
         {

--- a/isc.class.php
+++ b/isc.class.php
@@ -125,7 +125,7 @@ class ISC_Class {
         {
             // creates an infinite loop if not secured, see ISC_Public::list_post_attachments_with_sources()
             $content = apply_filters( 'the_content', $content );
-            
+
             /*$_image_urls = $this->_filter_src_attributes($_content);
             $_imgs = array();
 
@@ -136,7 +136,7 @@ class ISC_Class {
                     'src' => $_image_url
                 );
             }*/
-            
+
             $_imgs = $this->_filter_image_ids($content);
 
             // add thumbnail information
@@ -196,7 +196,7 @@ class ISC_Class {
 
             return $srcs;
         }
-        
+
         /**
          * filter image ids from text
 +        * @return array with image ids => image src uri-s
@@ -242,7 +242,7 @@ class ISC_Class {
                 }
 
                 return $srcs;
-        }        
+        }
 
         /**
          * get image by url accessing the database directly
@@ -266,7 +266,7 @@ class ISC_Class {
              *   additional query vars
              */
             $newurl = esc_url( preg_replace( "/(-e\d+){0,1}(-\d+x\d+){0,1}\.({$types})(.*)/i", '.${3}', $url ) );
-            
+
             // remove protocoll (http or https)
             $url = str_ireplace( array( 'http:', 'https:' ) , '', $url );
             $newurl = str_ireplace( array( 'http:', 'https:' ) , '', $newurl );
@@ -279,10 +279,10 @@ class ISC_Class {
                 "http:$newurl",
                 "https:$newurl"
             );
-            
+
             $query = apply_filters( 'isc_get_image_by_url_query', $raw_query, $newurl );
             $id = $wpdb->get_var($query);
-            
+
             return intval( $id );
         }
 
@@ -302,10 +302,10 @@ class ISC_Class {
 
             // add thumbnail information
             $thumb_id = get_post_thumbnail_id($post_id);
-            if ( !empty( $thumb_id )) { 
-                $image_ids[$thumb_id] = wp_get_attachment_url($thumb_id); 
+            if ( !empty( $thumb_id )) {
+                $image_ids[$thumb_id] = wp_get_attachment_url($thumb_id);
             }
-            
+
             // get urls from gallery images
             // this might not be needed, since the gallery shortcode might have run already, but just in case
             // only for php 5.3 and higher
@@ -400,7 +400,7 @@ class ISC_Class {
         */
         public function default_options()
         {
-                
+
                 $licences = "All Rights Reserved
 Public Domain Mark 1.0|https://creativecommons.org/publicdomain/mark/1.0/
 CC0 1.0 Universal|https://creativecommons.org/publicdomain/zero/1.0/
@@ -428,7 +428,7 @@ CC BY-ND 2.0 Generic|https://creativecommons.org/licenses/by-nd/2.0/
 CC BY-NC 2.0 Generic|https://creativecommons.org/licenses/by-nc/2.0/
 CC BY-NC-SA 2.0 Generic|https://creativecommons.org/licenses/by-nc-sa/2.0/
 CC BY-NC-ND 2.0 Generic|https://creativecommons.org/licenses/by-nc-nd/2.0/";
-                
+
             $default['display_type'] = array('list');
             $default['list_on_archives'] = false;
             $default['list_on_excerpts'] = false;
@@ -497,10 +497,10 @@ CC BY-NC-ND 2.0 Generic|https://creativecommons.org/licenses/by-nc-nd/2.0/";
         }
 
         /**
-         * transform the licences from the options textfield into an array
+         * transform the licenses from the options textfield into an array
          *
-         * @param string $licences text with licences
-         * @return array $new_licences array with licences and licence information
+         * @param string $licences text with licenses
+         * @return array $new_licences array with licenses and license information
          * @return false if no array created
          * @since 1.3.5
          */

--- a/public/public.php
+++ b/public/public.php
@@ -14,13 +14,13 @@ if (!class_exists('ISC_Public')) {
      * @todo move frontend-only functions from general class here
      */
     class ISC_Public extends ISC_Class {
-        
+
         public function __construct() {
             parent::__construct();
 
             add_action('wp_enqueue_scripts', array($this, 'front_scripts'));
             add_action('wp_head', array($this, 'front_head'));
-            
+
             /**
              * filters need to be above 10 in order to interpret also gallery shortcode
              */
@@ -69,7 +69,7 @@ if (!class_exists('ISC_Public')) {
          */
         public function content_filter($content)
         {
-            
+
             // display inline sources
             $options = $this->get_isc_options();
             if( isset($options['display_type']) && is_array($options['display_type']) && in_array('overlay', $options['display_type'] ) ) {
@@ -81,11 +81,11 @@ if (!class_exists('ISC_Public')) {
                 } else {
                     $content_after = '';
                 }
-                
+
                 /**
                  * removed [caption], because this check runs after the hook that interprets shortcodes
                  * img tag is checked individually since there is a different order of attributes when images are used in gallery or individually
-                 * 
+                 *
                  * 0 – full match
                  * 1 - <figure> if set
                  * 2 – alignment
@@ -97,55 +97,55 @@ if (!class_exists('ISC_Public')) {
                  * 8 – image URL
                  * 9 – (unused)
                  * 10 - </figure>
-                 * 
+                 *
                  * tested with:
                  * * with and without [caption]
                  * * with and without link attibute
-                 * 
+                 *
                  * potential issues:
                  * * line breaks in the code
                  */
                 $pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a [^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)>)? *(<img [^>]*[^>]*src="(.+)".*\/?>).*(</a>)??[^<]*).*(<\/figure.*>)?#isU';
                 $count = preg_match_all($pattern, $content, $matches);
-                
+
                 // error_log(print_r($content, true)); error_log(print_r($matches, true));
                 if (false !== $count) {
                     for ($i=0; $i < $count; $i++) {
-                        
+
                         /**
                          * interpret the image tag
-                         * 
+                         *
                          * we only need the ID if we don’t have it yet
                          * it can be retrieved from "wp-image-" class (single) or "aria-describedby="gallery-1-34" in gallery
                          */
                         $id = $matches[6][$i];
                         $img_tag = $matches[7][$i];
-                        
+
                         if( ! $id ){
                                 $success = preg_match('#wp-image-(\d+)|aria-describedby="gallery-1-(\d+)#is', $img_tag, $matches_id);
                                 if( $success ){
                                     $id = $matches_id[1] ? intval( $matches_id[1] ) : intval( $matches_id[2] );
                                 }
                         }
-                        
+
                         // if ID is still missing get image by URL
                         if( ! $id ){
                             $src = $matches[8][$i];
                             $id = $this->get_image_by_url($src);
                         }
-                        
+
                         // don’t show caption for own image if admin choose not to do so
                         if($options['exclude_own_images']){
                                 if(get_post_meta($id, 'isc_image_source_own', true)) {
                                         continue;
                                 }
                         }
-                        
+
                         // don’t display empty sources
                         if( !$source_string = $this->render_image_source_string( $id ) ) {
                                 continue;
                         }
-                        
+
                         // get any alignment from the original code
                         preg_match('#alignleft|alignright|alignnone|aligncenter#is', $matches[0][$i], $matches_align);
                         $alignment = isset( $matches_align[0] ) ? $matches_align[0] : '';
@@ -155,7 +155,7 @@ if (!class_exists('ISC_Public')) {
                         $new_content = str_replace('wp-image-' . $id, 'wp-image-' . $id . ' with-source', $old_content);
 
                         $content = str_replace($old_content, '<div id="isc_attachment_' . $id . '" class="isc-source ' . $alignment . '"> ' . $new_content . $source . '</div>', $content);
-                        
+
                     }
                 }
                 /**
@@ -163,10 +163,10 @@ if (!class_exists('ISC_Public')) {
                  */
                 $content = $content . $content_after;
             }
-            
+
             // attach image source list to content, if option is enabled
             if ((isset($options['list_on_archives']) && $options['list_on_archives']) ||
-                    (is_singular() && isset($options['display_type']) && is_array($options['display_type']) && in_array('list', $options['display_type']))) {                
+                    (is_singular() && isset($options['display_type']) && is_array($options['display_type']) && in_array('list', $options['display_type']))) {
                 $content = $content . $this->list_post_attachments_with_sources();
             }
 
@@ -217,20 +217,20 @@ if (!class_exists('ISC_Public')) {
                     return;
                 }
             }
-            
+
             $attachments = get_post_meta($post_id, 'isc_post_images', true);
 
             // if attachments is an empty string, search for images in it
             if ($attachments == '') {
                     // unregister our content filter in order to prevent infinite loops when calling the_content in the next steps
                     remove_filter( 'the_content', array( $this, 'content_filter' ), 20 );
-                    
+
                     $this->save_image_information_on_load();
                     $this->update_image_posts_meta($post_id, $post->post_content);
-                    
+
                     $attachments = get_post_meta($post_id, 'isc_post_images', true);
             }
-            
+
             $return = '';
             if (!empty($attachments)) {
                 $atts = array();
@@ -261,7 +261,7 @@ if (!class_exists('ISC_Public')) {
          *
          * @param array $attachments
          * @updated 1.3.5
-         * @updated 1.5 removed rendering the licence to an earlier function
+         * @updated 1.5 removed rendering the license to an earlier function
          */
         protected function render_attachments($attachments)
         {
@@ -452,11 +452,11 @@ if (!class_exists('ISC_Public')) {
             if (!is_array($atts) || $atts == array())
                 return;
             $options = $this->get_isc_options();
-            
+
             /**
              * added comment `isc_stop_overlay` as a class to the table to suppress overlays within it starting at that point
              * todo: allow overlays to start again after the table
-             * 
+             *
              */
             ?><div class="isc_all_image_list_box isc_stop_overlay">
             <table>
@@ -679,7 +679,7 @@ if (!class_exists('ISC_Public')) {
 
         /**
          * render source string of single image by its id
-         *  this only returns the string with source and licence (and urls),
+         *  this only returns the string with source and license (and urls),
          *  but no wrapping, because the string is used in a lot of functions
          *  (e.g. image source list where title is prepended)
          *
@@ -723,7 +723,7 @@ if (!class_exists('ISC_Public')) {
                 $source = sprintf('<a href="%2$s" target="_blank" rel="nofollow">%1$s</a>', $source, $metadata['source_url']);
             }
 
-            // add licence if enabled
+            // add license if enabled
             if($options['enable_licences'] && isset($metadata['licence']) && $metadata['licence']) {
                 $licences = $this->licences_text_to_array($options['licences']);
                 if(isset($licences[$metadata['licence']]['url'])) $licence_url = $licences[$metadata['licence']]['url'];
@@ -750,7 +750,7 @@ if (!class_exists('ISC_Public')) {
             if (empty($post->ID)) {
                 return;
             }
-            
+
             $post_id = $post->ID;
             $_content = $post->post_content;
 

--- a/readme.txt
+++ b/readme.txt
@@ -48,7 +48,7 @@ You can choose between different image source list types:
 * lists images with missing sources in the backend
 * warnings, if image source is missing
 * link sources to any url
-* manage, display and link licences
+* manage, display and link licenses
 
 **Localization**
 


### PR DESCRIPTION
Update licence instances to license in strings and comments but avoided code. This is for an en_US base localization so that Glossaries will pick up the term properly on translate.wp.org