### PR TITLE
Disable index on save

### DIFF
--- a/includes/log.php
+++ b/includes/log.php
@@ -26,6 +26,7 @@ class ISC_Log {
 
 		// get calling function
 		// source: https://stackoverflow.com/questions/190421/get-name-of-caller-function-in-php
+		// currently unused, keeping the code in case we need it again
 		$trace            = debug_backtrace();
 		$caller           = $trace[1];
 		$calling_function = '';
@@ -39,7 +40,7 @@ class ISC_Log {
 
 		$message = is_array( $message ) ? print_r( $message, true ) : $message;
 
-		error_log( '[' . date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) . ", $calling_function] $message\n", 3, self::get_log_file_path() );
+		error_log( '[' . date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) . "] $message\n", 3, self::get_log_file_path() );
 	}
 
 	/**

--- a/includes/model.php
+++ b/includes/model.php
@@ -51,7 +51,7 @@ class ISC_Model {
 		// todo: maybe handle thumbnails here as well, the content is different, though
 
 		// retrieve images added to a post or page and save all information as a post meta value for the post
-		self::save_image_information( $post_id, $image_ids );
+		self::update_post_images_meta( $post_id, $image_ids );
 
 		// add the post ID to the list of posts associated with a given image
 		self::update_image_posts_meta( $post_id, $image_ids );
@@ -157,9 +157,9 @@ class ISC_Model {
 	 *
 	 * @todo check for more post types that maybe should not be parsed here
 	 */
-	public static function save_image_information( $post_id, $image_ids ) {
+	public static function update_post_images_meta( $post_id, $image_ids ) {
 
-		ISC_Log::log( 'enter save_image_information()' );
+		ISC_Log::log( 'enter update_post_images_meta()' );
 
 		// add thumbnail information
 		$thumb_id = get_post_thumbnail_id( $post_id );
@@ -409,7 +409,7 @@ class ISC_Model {
 		ISC_Log::log( 'enter filter_image_ids() to look for image IDs within the content' );
 
 		if ( empty( $content ) ) {
-			ISC_Log::log( 'exit save_image_information() due to missing content' );
+			ISC_Log::log( 'exit filter_image_ids() due to missing content' );
 			return $srcs;
 		}
 

--- a/includes/model.php
+++ b/includes/model.php
@@ -15,8 +15,6 @@ class ISC_Model {
 	 * Setup registers filters and actions.
 	 */
 	public function __construct() {
-		// save image information in meta field after a post was saved
-		// add_action( 'wp_insert_post', array( $this, 'save_image_information_on_post_save' ), 10, 2 );
 		// attachment field handling
 		add_action( 'add_attachment', array( $this, 'attachment_added' ), 10, 2 );
 		add_filter( 'attachment_fields_to_save', array( $this, 'isc_fields_save' ), 10, 2 );
@@ -32,54 +30,44 @@ class ISC_Model {
 	}
 
 	/**
-	 * Save image information to a post when it is saved
+	 * Update the isc_image_posts and isc_post_images indexes
 	 *
-	 * @since 1.1
-	 * @param integer $post_id post id.
-	 * @param WP_Post $post post object.
+	 * @since 2.0
+	 * @param integer $post_id ID of the target post.
+	 * @param string  $content content of the target post.
 	 */
-	public function save_image_information_on_post_save( $post_id, $post ) {
-
-		// don’t run on autosave of AJAX requests
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
-			 || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-			return;
-		}
+	public static function update_indexes( $post_id, $content ) {
 
 		// check if we can even save the image information
-		if ( ! $this->can_save_image_information( $post, $post_id ) ) {
+		// abort on archive pages since some output from other plugins might be disabled here
+		if (
+			is_archive()
+			|| is_home()
+			|| ! self::can_save_image_information( $post_id ) ) {
 			return;
 		}
 
-		$content = '';
-		if ( ! empty( $post->post_content ) ) {
-			$content = stripslashes( $post->post_content );
-		} else {
-			// retrieve content with Gutenberg, because no content included in $_POST object then
-			// todo: check if this is really needed after we also have access to the $post object here.
-			$_post = get_post( $post_id );
-			if ( isset( $_post->post_content ) ) {
-				$content = $_post->post_content;
-			}
-		}
+		$image_ids = self::filter_image_ids( $content );
+		// todo: maybe handle thumbnails here as well, the content is different, though
 
-		// Needs to be called before the 'isc_post_images' field is updated.
-		$this->update_image_posts_meta( $post_id, $content );
-		$this->save_image_information( $post_id, $content );
+		// retrieve images added to a post or page and save all information as a post meta value for the post
+		self::save_image_information( $post_id, $image_ids );
+
+		// add the post ID to the list of posts associated with a given image
+		self::update_image_posts_meta( $post_id, $image_ids );
 	}
 
 	/**
-	 * Update isc_image_posts meta field for all images found in a post with a given ID.
+	 * Update isc_image_posts meta field with includes IDs of all posts that have the image in its content
+	 * the function should be used to push a post ID to the (maybe) existing meta field
 	 *
 	 * @param integer $post_id ID of the target post.
-	 * @param string  $content content of the target post.
-	 * @updated 1.3.5 added images_in_posts_simple filter
+	 * @param array   $image_ids IDs of the attachments in the content.
 	 */
-	public function update_image_posts_meta( $post_id, $content ) {
-		ISC_Public::remove_the_content_filters();
-		$content = apply_filters( 'the_content', $content );
+	public static function update_image_posts_meta( $post_id, $image_ids ) {
 
-		$image_ids      = ISC_Class::get_instance()->filter_image_ids( $content );
+		ISC_Log::log( 'enter update_image_posts_meta()' );
+
 		$added_images   = array();
 		$removed_images = array();
 
@@ -87,6 +75,7 @@ class ISC_Model {
 		$thumb_id = get_post_thumbnail_id( $post_id );
 		if ( ! empty( $thumb_id ) ) {
 			$image_ids[ $thumb_id ] = wp_get_attachment_url( $thumb_id );
+			ISC_Log::log( 'thumbnail found with ID' . $thumb_id );
 		}
 
 		// apply filter to image array, so other developers can add their own logic
@@ -108,6 +97,7 @@ class ISC_Model {
 
 		foreach ( $image_ids as $id => $url ) {
 			if ( is_array( $isc_post_images ) && ! array_key_exists( $id, $isc_post_images ) ) {
+				ISC_Log::log( 'add new image: ' . $id );
 				array_push( $added_images, $id );
 			}
 		}
@@ -116,6 +106,7 @@ class ISC_Model {
 				// if (!in_array($old_id, $image_ids)) {
 				if ( ! array_key_exists( $old_id, $image_ids ) ) {
 					array_push( $removed_images, $old_id );
+					ISC_Log::log( 'remove image: ' . $id );
 				} else {
 					if ( ! empty( $old_id ) ) {
 						$meta = get_post_meta( $old_id, 'isc_image_posts', true );
@@ -161,42 +152,14 @@ class ISC_Model {
 	/**
 	 * Retrieve images added to a post or page and save all information as a post meta value for the post
 	 *
-	 * @since 1.1
-	 * @updated 1.3.5 added isc_images_in_posts filter
-	 * @todo check for more post types that maybe should not be parsed here
-	 *
 	 * @param integer $post_id ID of a post.
-	 * @param string  $content post content.
+	 * @param array   $image_ids IDs of the attachments in the content.
+	 *
+	 * @todo check for more post types that maybe should not be parsed here
 	 */
-	public function save_image_information( $post_id, $content = '' ) {
+	public static function save_image_information( $post_id, $image_ids ) {
 
 		ISC_Log::log( 'enter save_image_information()' );
-
-		// creates an infinite loop if not secured, see ISC_Public::list_post_attachments_with_sources()
-		// we need to unregister our own content filters before running these
-		ISC_Public::remove_the_content_filters();
-		$content = apply_filters( 'the_content', $content );
-		// ISC_Public::register_the_content_filters();
-
-		/*
-		$_image_urls = $this->filter_src_attributes($_content);
-		$_imgs = array();
-
-		foreach ($_image_urls as $_image_url) {
-			// get ID of images by url
-			$img_id = $this->get_image_by_url($_image_url);
-			$_imgs[$img_id] = array(
-				'src' => $_image_url
-			);
-		}*/
-
-		// check if we can even save the image information
-		if ( ! $this->can_save_image_information( null, $post_id ) ) {
-			ISC_Log::log( 'exit save_image_information() because we cannot save image information for post ID ' . $post_id );
-			return;
-		}
-
-		$_imgs = ISC_Class::get_instance()->filter_image_ids( $content );
 
 		// add thumbnail information
 		$thumb_id = get_post_thumbnail_id( $post_id );
@@ -205,24 +168,29 @@ class ISC_Model {
 		 * If an image is used both inside the post and as post thumbnail, the thumbnail entry overrides the regular image.
 		 */
 		if ( ! empty( $thumb_id ) ) {
-			$_imgs[ $thumb_id ] = array(
+			$image_ids[ $thumb_id ] = array(
 				'src'       => wp_get_attachment_url( $thumb_id ),
 				'thumbnail' => true,
 			);
+			ISC_Log::log( 'thumbnail found with ID' . $thumb_id );
 		}
 
 		// apply filter to image array, so other developers can add their own logic
-		$_imgs = apply_filters( 'isc_images_in_posts', $_imgs, $post_id );
+		$image_ids = apply_filters( 'isc_images_in_posts', $image_ids, $post_id );
 
-		if ( empty( $_imgs ) ) {
-			$_imgs = array();
+		if ( empty( $image_ids ) ) {
+			$image_ids = array();
 		}
-		update_post_meta( $post_id, 'isc_post_images', $_imgs );
+
+		ISC_Log::log( 'save isc_post_images with size of ' . count( $image_ids ) );
+
+		update_post_meta( $post_id, 'isc_post_images', $image_ids );
 	}
 
 	/**
 	 * Add meta values to all attachments
 	 *
+	 * @todo probably deprecated
 	 * @todo probably need to fix this when more fields are added along the way
 	 * @todo use compare => 'NOT EXISTS' when WP 3.5 is up to retrieve only values where it is not set
 	 * @todo this currently updates all empty fields; empty in this context is empty string, 0, false or not existing; add check if meta field already existed before
@@ -305,15 +273,12 @@ class ISC_Model {
 	 * ignore also attachment posts
 	 * ignore revisions
 	 *
-	 * @param WP_Post $post post object.
 	 * @param integer $post_id WP_Post ID. Useful if post object is not given.
 	 */
-	private function can_save_image_information( $post, $post_id = null ) {
+	private static function can_save_image_information( $post_id = null ) {
 
-		// load post if not given
-		if ( ! $post || ! $post instanceof WP_Post ) {
-			$post = get_post( $post_id );
-		}
+		// load post
+		$post = get_post( $post_id );
 
 		if ( ! isset( $post->post_type )
 			 || ! in_array( $post->post_type, get_post_types( array( 'public' => true ), 'names' ), true ) // is the post type public
@@ -326,6 +291,30 @@ class ISC_Model {
 	}
 
 	/**
+	 * Remove post_images index
+	 * namely the post meta field `isc_post_images`
+	 *
+	 * @return int|false The number of rows updated, or false on error.
+	 */
+	public static function clear_post_images_index() {
+		global $wpdb;
+
+		return $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_post_images' ), array( '%s' ) );
+	}
+
+	/**
+	 * Remove image_posts index
+	 * namely the post meta field `isc_image_posts`
+	 *
+	 * @return int|false The number of rows updated, or false on error.
+	 */
+	public static function clear_image_posts_index() {
+		global $wpdb;
+
+		return $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_posts' ), array( '%s' ) );
+	}
+
+	/**
 	 * Remove all image-post relations
 	 * this concerns the post meta fields `isc_image_posts` and `isc_post_images`
 	 *
@@ -334,8 +323,8 @@ class ISC_Model {
 	public static function clear_index() {
 		global $wpdb;
 
-		$rows_deleted_1 = $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_post_images' ), array( '%s' ) );
-		$rows_deleted_2 = $wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_posts' ), array( '%s' ) );
+		$rows_deleted_1 = self::clear_post_images_index();
+		$rows_deleted_2 = self::clear_image_posts_index();
 
 		if ( false !== $rows_deleted_1 && false !== $rows_deleted_2 ) {
 			return $rows_deleted_1 + $rows_deleted_2;
@@ -406,5 +395,112 @@ class ISC_Model {
 			set_transient( 'isc-show-missing-sources-warning', 'no', DAY_IN_SECONDS );
 			return 'no';
 		}
+	}
+
+	/**
+	 * Filter image ids from content
+	 *
+	 * @param string $content post content.
+	 * @return array with image ids => image src uri-s
+	 */
+	public static function filter_image_ids( $content = '' ) {
+		$srcs = array();
+
+		ISC_Log::log( 'enter filter_image_ids() to look for image IDs within the content' );
+
+		if ( empty( $content ) ) {
+			ISC_Log::log( 'exit save_image_information() due to missing content' );
+			return $srcs;
+		}
+
+		// parse HTML with DOM
+		$dom = new DOMDocument();
+
+		libxml_use_internal_errors( true );
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' );
+		}
+		$dom->loadHTML( $content );
+
+		// Prevents from sending E_WARNINGs notice (Outputs are forbidden during activation)
+		libxml_clear_errors();
+
+		foreach ( $dom->getElementsByTagName( 'img' ) as $node ) {
+			if ( isset( $node->attributes ) ) {
+				$matched = false;
+				if ( null !== $node->attributes->getNamedItem( 'class' ) ) {
+
+					ISC_Log::log( sprintf( 'found class attribute "%s"', $node->attributes->getNamedItem( 'class' )->textContent ) );
+
+					if ( preg_match( '#.*wp-image-(\d+?).*#U', $node->attributes->getNamedItem( 'class' )->textContent, $matches ) ) {
+						$srcs[ intval( $matches[1] ) ] = $node->attributes->getNamedItem( 'src' )->textContent;
+						$matched                       = true;
+
+						ISC_Log::log( sprintf( 'found image ID "%d" with src "%s"', intval( $matches[1] ), $srcs[ intval( $matches[1] ) ] ) );
+					}
+				}
+				if ( ! $matched ) {
+					if ( null !== $node->attributes->getNamedItem( 'src' ) ) {
+						$url = $node->attributes->getNamedItem( 'src' )->textContent;
+						ISC_Log::log( sprintf( 'found src "%s"', $url ) );
+						// get ID of images by url
+						$id = self::get_image_by_url( $url );
+						if ( $id ) {
+							$srcs[ $id ] = $url;
+						}
+					}
+				}
+			}
+		}
+
+		return $srcs;
+	}
+
+	/**
+	 * Get image by url accessing the database directly
+	 *
+	 * @since 1.1
+	 * @updated 1.1.3
+	 * @param string $url url of the image.
+	 * @return integer ID of the image.
+	 */
+	public static function get_image_by_url( $url = '' ) {
+		global $wpdb;
+
+		ISC_Log::log( 'enter get_image_by_url() to look for URL ' . $url );
+
+		if ( empty( $url ) ) {
+			return 0;
+		}
+		$types = implode( '|', ISC_Class::get_instance()->allowed_extensions );
+		/**
+		 * Check for the format 'image-title-(e12452112-)300x200.jpg(?query…)' and removes
+		 *   the image size
+		 *   edit marks
+		 *   additional query vars
+		 */
+		$newurl = esc_url( preg_replace( "/(-e\d+){0,1}(-\d+x\d+){0,1}\.({$types})(.*)/i", '.${3}', $url ) );
+
+		// remove protocoll (http or https)
+		$url    = str_ireplace( array( 'http:', 'https:' ), '', $url );
+		$newurl = str_ireplace( array( 'http:', 'https:' ), '', $newurl );
+
+		// not escaped, because escaping already happened above
+		$raw_query = $wpdb->prepare(
+			"SELECT ID FROM `$wpdb->posts` WHERE post_type='attachment' AND guid = %s OR guid = %s OR guid = %s OR guid = %s LIMIT 1",
+			"http:$url",
+			"https:$url",
+			"http:$newurl",
+			"https:$newurl"
+		);
+
+		ISC_Log::log( 'SQL: ' . $raw_query );
+
+		$query = apply_filters( 'isc_get_image_by_url_query', $raw_query, $newurl );
+		$id    = $wpdb->get_var( $query );
+
+		$id ? ISC_Log::log( 'found image ID ' . $id ) : ISC_Log::log( 'found image ID –' );
+
+		return intval( $id );
 	}
 }

--- a/includes/model.php
+++ b/includes/model.php
@@ -16,7 +16,7 @@ class ISC_Model {
 	 */
 	public function __construct() {
 		// save image information in meta field after a post was saved
-		add_action( 'wp_insert_post', array( $this, 'save_image_information_on_post_save' ), 10, 2 );
+		// add_action( 'wp_insert_post', array( $this, 'save_image_information_on_post_save' ), 10, 2 );
 		// attachment field handling
 		add_action( 'add_attachment', array( $this, 'attachment_added' ), 10, 2 );
 		add_filter( 'attachment_fields_to_save', array( $this, 'isc_fields_save' ), 10, 2 );

--- a/isc.php
+++ b/isc.php
@@ -1,7 +1,7 @@
 <?php
 /*
   Plugin Name: Image Source Control
-  Version: 1.10.4
+  Version: 2.0 alpha
   Plugin URI: https://webgilde.com/en/image-source-control/
   Description: The Image Source Control saves the source of an image, lists them and warns if it is missing.
   Author: Thomas Maier

--- a/public/public.php
+++ b/public/public.php
@@ -913,28 +913,4 @@ class ISC_Public extends ISC_Class {
 
 		return $source;
 	}
-
-	/**
-	 * Save image information for a post when it is viewed –� only called when using isc_list function
-	 * (to help indexing old posts)
-	 *
-	 * @since 1.1
-	 * @deprecated
-	 */
-	public function save_image_information_on_load() {
-		global $post;
-
-		ISC_Log::log( 'enter save_image_information_on_load()' );
-
-		if ( empty( $post->ID ) ) {
-			ISC_Log::log( 'exit save_image_information_on_load() due to empty post ID' );
-			return;
-		}
-
-		$post_id  = $post->ID;
-		$_content = $post->post_content;
-
-		$this->model->save_image_information( $post_id, $_content );
-	}
-
 }

--- a/public/public.php
+++ b/public/public.php
@@ -331,16 +331,16 @@ class ISC_Public extends ISC_Class {
 
 				// check if source of own images can be displayed
 				if ( ( $own == '' && $source == '' ) || ( $own != '' && $this->options['exclude_own_images'] ) ) {
-					if ( $own != '' && $this->options['exclude_own_images'] ) {
-						ISC_Log::log( 'skipped because "own" sources are excluded for image ' . $attachment_id );
-					} else {
-						ISC_Log::log( 'skipped because of empty source for image ' . $attachment_id );
-					}
+				    if ( $own != '' && $this->options['exclude_own_images'] ) {
+					    ISC_Log::log( sprintf( 'image %d: "own" sources are excluded', $attachment_id ) );
+				    } else {
+					    ISC_Log::log( sprintf( 'image %d: skipped because of empty source', $attachment_id ) );
+				    }
 					unset( $atts[ $attachment_id ] );
 					continue;
 				} else {
 					$atts[ $attachment_id ]['title'] = get_the_title( $attachment_id );
-					ISC_Log::log( sprintf( 'getting title for image %d: %s', $attachment_id, $atts[ $attachment_id ]['title'] ) );
+					ISC_Log::log( sprintf( 'image %d: getting title "%s"', $attachment_id, $atts[ $attachment_id ]['title'] ) );
 					$atts[ $attachment_id ]['source'] = $this->render_image_source_string( $attachment_id );
 				}
 			}

--- a/public/public.php
+++ b/public/public.php
@@ -41,20 +41,21 @@ class ISC_Public extends ISC_Class {
 	 * Register our the_content filters
 	 */
 	public static function register_the_content_filters() {
+
 		// Content filters need to be above 10 in order to interpret also gallery shortcode
-		// registering the classes using an instance so that we remove the filter somewhere else
-		add_filter( 'the_content', array( self::get_instance(), 'add_source_captions_to_content' ), 20 );
-		// this filter needs to be used in the call to remove_filter() in the list_post_attachments_with_sources() function to prevent an infinite loop
-		add_filter( 'the_content', array( self::get_instance(), 'add_source_list_to_content' ), 21 );
+		// needs to be added to remove_the_content_filters() as well to prevent infinite loops
+		add_filter( 'the_content', array( self::get_instance(), 'add_sources_to_content' ), 20 );
 	}
 
 	/**
 	 * Unregister our the_content filters
 	 * used in places where we want to prevent infinite loops
+	 *
+	 * @deprecated probably deprecated after ISC ist not using apply_filter( 'the_content' ) anymore.
 	 */
 	public static function remove_the_content_filters() {
-		remove_filter( 'the_content', array( self::get_instance(), 'add_source_captions_to_content' ), 20 );
-		remove_filter( 'the_content', array( self::get_instance(), 'add_source_list_to_content' ), 21 );
+
+		remove_filter( 'the_content', array( self::get_instance(), 'add_sources_to_content' ), 20 );
 	}
 
 	/**
@@ -96,6 +97,60 @@ class ISC_Public extends ISC_Class {
 	}
 
 	/**
+	 * Find images in the content, create the index, and maybe add sources to it
+	 *
+	 * @param string $content post content.
+	 * @return string $content
+	 */
+	public function add_sources_to_content( $content ) {
+
+		// create a new line in the log to separate different posts
+		ISC_Log::log( '---' );
+
+		// disabling the content filters while working in page builders or block editor
+		if ( wp_is_json_request() || defined( 'REST_REQUEST' ) ) {
+			ISC_Log::log( 'skipped adding sources while working in page builders' );
+			return;
+		}
+
+		global $post;
+
+		if ( empty( $post->ID ) ) {
+			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+				ISC_Log::log( 'exit content for ' . $_SERVER['REQUEST_URI'] . ' due to missing post_id' );
+			}
+			return $content;
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			ISC_Log::log( 'index content for ' . $_SERVER['REQUEST_URI'] . ' and post ID ' . $post->ID );
+		}
+
+		// create index, if doesn’t exist, yet
+		$attachments = get_post_meta( $post->ID, 'isc_post_images', true );
+
+		/**
+		 * $attachments is an empty string if it was never set and an array if it was set
+		 * the array is empty if no images were found in the past. This prevents re-indexing as well
+		 */
+		if ( $attachments === '' ) {
+			ISC_Log::log( 'isc_post_images is empty. Updating index for post ID ' . $post->ID );
+
+			// retrieve images added to a post or page and save all information as a post meta value for the post
+			ISC_Model::update_indexes( $post->ID, $content );
+		} elseif ( is_array( $attachments ) ) {
+			ISC_Log::log( sprintf( 'found existing list of %d sources for post ID %d', count( $attachments ), $post->ID ) );
+		}
+
+		// maybe add source captions
+		$content = self::add_source_captions_to_content( $content );
+		// maybe add source list
+		$content = self::add_source_list_to_content( $content );
+
+		return $content;
+
+	}
+	/**
 	 * Add captions to post content and include source into caption, if this setting is enabled
 	 *
 	 * @param string $content post content.
@@ -103,11 +158,9 @@ class ISC_Public extends ISC_Class {
 	 */
 	public function add_source_captions_to_content( $content ) {
 
-		// create a new line in the log to separate different posts
-		ISC_Log::log( '---' );
+		$options = $this->get_isc_options();
 
 		// display inline sources
-		$options = $this->get_isc_options();
 		if ( empty( $options['display_type'] ) || ! is_array( $options['display_type'] ) || ! in_array( 'overlay', $options['display_type'], true ) ) {
 			ISC_Log::log( 'not creating image overlays because the option is disabled' );
 			return $content;
@@ -228,11 +281,11 @@ class ISC_Public extends ISC_Class {
 
 		/**
 		 * Display the image source list below the content
-         * on single pages if the following option is enabled: How to display source in Frontend > list below content
-         * on archive pages and home pages with posts if the following option is enabled: Archive Pages > Display sources list below full posts
+		 * on single pages if the following option is enabled: How to display source in Frontend > list below content
+		 * on archive pages and home pages with posts if the following option is enabled: Archive Pages > Display sources list below full posts
 		 */
 		if ( ( ( is_archive() || is_home() )
-               && isset( $options['list_on_archives'] ) && $options['list_on_archives'] ) ||
+			   && isset( $options['list_on_archives'] ) && $options['list_on_archives'] ) ||
 			 ( is_singular() && isset( $options['display_type'] ) && is_array( $options['display_type'] ) && in_array( 'list', $options['display_type'], true ) ) ) {
 			ISC_Log::log( 'start creating source list below content' );
 			$content = $content . $this->list_post_attachments_with_sources();
@@ -279,8 +332,6 @@ class ISC_Public extends ISC_Class {
 	public function list_post_attachments_with_sources( $post_id = 0 ) {
 		global $post;
 
-		// ISC_Log::log( debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS ) );
-
 		if ( empty( $post_id ) && ! empty( $post->ID ) ) {
 				$post_id = $post->ID;
 		}
@@ -307,20 +358,6 @@ class ISC_Public extends ISC_Class {
 
 		$attachments = get_post_meta( $post_id, 'isc_post_images', true );
 
-		// if attachments is an empty string, search for images in it
-		if ( $attachments == '' ) {
-				ISC_Log::log( 'isc_post_images is empty for post ID ' . $post_id );
-				// unregister our content filter in order to prevent infinite loops when calling the_content in the next steps
-				// todo: there also seems to be a loop caused by REST requests as reported and hotfixed in https://github.com/webgilde/image-source-control/issues/48
-				remove_filter( 'the_content', array( self::get_instance(), 'add_source_list_to_content' ), 21 );
-
-				$this->save_image_information_on_load();
-				// the following might not be needed anymore.
-				// $this->model->update_image_posts_meta( $post_id, $post->post_content );
-
-				$attachments = get_post_meta( $post_id, 'isc_post_images', true );
-		}
-
 		if ( ! empty( $attachments ) ) {
 			ISC_Log::log( sprintf( 'going through %d attachments', count( $attachments ) ) );
 			$atts = array();
@@ -331,11 +368,11 @@ class ISC_Public extends ISC_Class {
 
 				// check if source of own images can be displayed
 				if ( ( $own == '' && $source == '' ) || ( $own != '' && $this->options['exclude_own_images'] ) ) {
-				    if ( $own != '' && $this->options['exclude_own_images'] ) {
-					    ISC_Log::log( sprintf( 'image %d: "own" sources are excluded', $attachment_id ) );
-				    } else {
-					    ISC_Log::log( sprintf( 'image %d: skipped because of empty source', $attachment_id ) );
-				    }
+					if ( $own != '' && $this->options['exclude_own_images'] ) {
+						ISC_Log::log( sprintf( 'image %d: "own" sources are excluded', $attachment_id ) );
+					} else {
+						ISC_Log::log( sprintf( 'image %d: skipped because of empty source', $attachment_id ) );
+					}
 					unset( $atts[ $attachment_id ] );
 					continue;
 				} else {
@@ -882,6 +919,7 @@ class ISC_Public extends ISC_Class {
 	 * (to help indexing old posts)
 	 *
 	 * @since 1.1
+	 * @deprecated
 	 */
 	public function save_image_information_on_load() {
 		global $post;

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- the full source list is now updated when a post is visited for the first time not after being saved
 - introducing a model class
 - introduced debug option
 - rewrite of the block options to make them more stable


### PR DESCRIPTION
rewritten logic to create the index for images belonging to posts and vice versa. This is now solely happening when a post / page is visited in the frontend and not when it is saved. The latter created issues with page builders and keeping the same logic working with frontend and backend proved to just make the code overly complex for no additional gain.