### PR TITLE
fixed replacement for overlays

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -205,12 +205,12 @@ class ISC_Public extends ISC_Class {
 		 *
 		 * tested with:
 		 * * with and without [caption]
-		 * * with and without link attibute
+		 * * with and without link attribute
 		 *
 		 * potential issues:
 		 * * line breaks in the code
 		 */
-		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a [^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)>)? *(<img [^>]*[^>]*src="(.+)".*\/?>).*(</a>)??[^<]*).*(<\/figure.*>)?#isU';
+		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a [^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)? *(<img [^>]*[^>]*src="(.+)".*\/?>).*(</a>)??[^<]*).*(<\/figure.*>)?#isU';
 		$count   = preg_match_all( $pattern, $content, $matches );
 
 		ISC_Log::log( 'embedded images found: ' . $count );

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= 2.1.1 =
+
+- fix source overlays for images with links
+
 = 2.1.0 =
 
 - rewritten jQuery to vanilla JavaScript in the frontend code


### PR DESCRIPTION
Fix regex that looks for images to also consider link tags that don’t have a `rel` attribute

Fixes #100 