### PR TITLE
remove jQuery shorthands

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -86,7 +86,7 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Add scripts to admin pages
+	 * Add scripts to ISC-related pages
 	 *
 	 * @since 1.0
 	 * @update 1.1.1
@@ -94,8 +94,11 @@ class ISC_Admin extends ISC_Class {
 	 * @param string $hook settings page hool.
 	 */
 	public function add_admin_scripts( $hook ) {
-		wp_enqueue_script( 'isc_script', plugins_url( '/assets/js/isc.js', __FILE__ ), false, ISCVERSION );
-		wp_enqueue_style( 'isc_image_settings_css', plugins_url( '/assets/css/isc.css', __FILE__ ), false, ISCVERSION );
+		$screen = get_current_screen();
+		if( isset( $screen->id ) && in_array( $screen->id, array( 'settings_page_isc-settings', 'media_page_isc-sources' ) ) ) {
+			wp_enqueue_script( 'isc_script', plugins_url( '/assets/js/isc.js', __FILE__ ), false, ISCVERSION );
+			wp_enqueue_style( 'isc_image_settings_css', plugins_url( '/assets/css/isc.css', __FILE__ ), false, ISCVERSION );
+		}
 	}
 
 	/**

--- a/admin/assets/js/isc.js
+++ b/admin/assets/js/isc.js
@@ -2,22 +2,24 @@ jQuery( document ).ready(
 	function($) {
 		isc_thumbnail_input_checkstate();
 		isc_caption_checkstate();
-		$( '#isc-settings-overlay-enable' ).click( function(){isc_caption_checkstate()} );
-		$( '.isc-settings-standard-source input' ).change( isc_toggle_standard_source_text );
-		$( '#use-thumbnail' ).click(
+		$( '#isc-settings-overlay-enable' ).on( 'click', function(){ isc_caption_checkstate() } );
+		$( '.isc-settings-standard-source input' ).on( 'change', isc_toggle_standard_source_text );
+		$( '#use-thumbnail' ).on(
+			'click',
 			function(){
-				if ('disabled' == $( '#thumbnail-size-select' ).attr( 'disabled' )) {
-					$( '#thumbnail-size-select' ).removeAttr( 'disabled' );
+				if ( document.getElementById( 'thumbnail-size-select' ).disabled ) {
+					document.getElementById( 'thumbnail-size-select' ).removeAttribute( 'disabled' );
 				} else {
-					$( '#thumbnail-size-select' ).attr( 'disabled', 'disabled' );
+					document.getElementById( 'thumbnail-size-select' ).setAttribute( 'disabled', 'disabled' );
 				}
 			}
 		);
-		$( '#thumbnail-size-select' ).change( function(){isc_thumbnail_input_checkstate()} );
+		$( '#thumbnail-size-select' ).on( 'change', function(){isc_thumbnail_input_checkstate()} );
 
 		// debug function – load image-post relations
 		// call post-image relation (meta fields saved for posts)
-		$( '#isc-list-post-image-relation' ).click(
+		$( '#isc-list-post-image-relation' ).on(
+			'click',
 			function(){
 				// disable the button
 				var button      = this;
@@ -47,7 +49,8 @@ jQuery( document ).ready(
 			}
 		);
 		// call image-post relation (meta fields saved for posts)
-		$( '#isc-list-image-post-relation' ).click(
+		$( '#isc-list-image-post-relation' ).on(
+			'click',
 			function(){
 				// disable the button
 				var button      = this;
@@ -75,7 +78,8 @@ jQuery( document ).ready(
 			}
 		);
 		// remove image-post index
-		$( '#isc-clear-index' ).click(
+		$( '#isc-clear-index' ).on(
+			'click',
 			function(){
 
 				var areYouSure = confirm( isc_data.confirm_message );
@@ -116,6 +120,7 @@ jQuery( document ).ready(
 /**
  * Toggle the state of the thumbnail size options in the plugin settings
  * to only enable them if the "custom" thumbnails size is used
+ *
  * @todo: also disable them when the "thumbnail" option itself is unchecked
  */
 function isc_thumbnail_input_checkstate(){
@@ -133,10 +138,20 @@ function isc_thumbnail_input_checkstate(){
  * disable them if the Overlay position option is not enabled
  */
 function isc_caption_checkstate() {
-	if (false == jQuery( '#isc-settings-overlay-enable' ).prop( 'checked' )) {
-		jQuery( '.isc_settings_section_overlay' ).find( 'input, select' ).attr( 'disabled', 'disabled' );
+	var overlay_option = document.getElementById( 'isc-settings-overlay-enable' );
+
+	if ( ! overlay_option ) {
+		return;
+	}
+	var elements = document.querySelectorAll( '.isc_settings_section_overlay input, .isc_settings_section_overlay input, select' );
+	if ( overlay_option.checked ) {
+		Array.prototype.forEach.call( elements, function(el, i) {
+			el.removeAttribute( 'disabled' );
+		} );
 	} else {
-		jQuery( '.isc_settings_section_overlay' ).find( 'input, select' ).removeAttr( 'disabled' );
+		Array.prototype.forEach.call( elements, function(el, i) {
+			el.setAttribute( 'disabled', 'disabled' );
+		} );
 	}
 }
 
@@ -144,9 +159,15 @@ function isc_caption_checkstate() {
  * Toggle the state of the Custom Text option in the Standard Sources settings
  */
 function isc_toggle_standard_source_text() {
-	if ( jQuery( '#isc-custom-text-select' ).is( ':checked' ) ) {
-		jQuery( '#isc-custom-text' ).removeAttr( 'disabled' );
+	var standard_source_custom = document.getElementById( 'isc-custom-text-select' );
+
+	if ( ! standard_source_custom ) {
+		return;
+	}
+
+	if ( standard_source_custom.checked ) {
+		document.getElementById( 'isc-custom-text' ).removeAttribute( 'disabled' );
 	} else {
-		jQuery( '#isc-custom-text' ).attr( 'disabled', 'disabled' );
+		document.getElementById( 'isc-custom-text' ).setAttribute( 'disabled', 'disabled' );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,11 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- only load ISC-related scripts on the plugin’s admin pages
+- fix jQuery shorthand warnings in the backend
+
 = 2.1.1 =
 
 - fix source overlays for images with links


### PR DESCRIPTION
- load `isc.js` only on ISC-related admin pages
- replace jQuery shorthands with `on`
- replace `removeAttribute` and `attr` with vanilla JS

Fixes #99